### PR TITLE
add additional-details option

### DIFF
--- a/README.md
+++ b/README.md
@@ -66,7 +66,7 @@ jobs:
     
     # Additional details to include in the summary comment
     # Default: ''
-    additional-details: 'For more information, see our [end-to-end test readme](link)'
+    custom-info: 'For more information, see our [end-to-end test readme](link)'
 
     # Create a job summary comment for the workflow run
     # Default: false

--- a/README.md
+++ b/README.md
@@ -63,6 +63,10 @@ jobs:
     # Title/headline to use for the created pull request comment.
     # Default: Playwright test results
     comment-title: 'Results'
+    
+    # Additional details to include in the summary comment
+    # Default: ''
+    additional-details: 'For more information, see our [end-to-end test readme](link)'
 
     # Create a job summary comment for the workflow run
     # Default: false

--- a/__tests__/__snapshots__/report.test.ts.snap
+++ b/__tests__/__snapshots__/report.test.ts.snap
@@ -13,7 +13,8 @@ exports[`renderReportSummary matches snapshot 1`] = `
 ![report](https://icongr.am/octicons/package.svg?size=14&color=abb4bf)  [Open report ↗︎](https://example.com/report)  
 ![stats](https://icongr.am/octicons/pulse.svg?size=14&color=abb4bf)  14 tests across 4 suites  
 ![duration](https://icongr.am/octicons/clock.svg?size=14&color=abb4bf)  1.1 seconds  
-![commit](https://icongr.am/octicons/git-pull-request.svg?size=14&color=abb4bf)  1234567
+![commit](https://icongr.am/octicons/git-pull-request.svg?size=14&color=abb4bf)  1234567  
+![info](https://icongr.am/octicons/info.svg?size=14&color=abb4bf)  For more information, see our [documentation](https://example.com/docs)
 
 <details open><summary><strong>Failed tests</strong></summary>
 

--- a/__tests__/report.test.ts
+++ b/__tests__/report.test.ts
@@ -141,6 +141,7 @@ describe('renderReportSummary', () => {
 	const renderOptions = {
 		title: 'Test Report',
 		reportUrl: 'https://example.com/report',
+		additionalDetails: 'For more information, see our [documentation](https://example.com/docs)',
 		commit: '1234567'
 	}
 	const getReportSummary = async (): Promise<string> =>

--- a/__tests__/report.test.ts
+++ b/__tests__/report.test.ts
@@ -141,7 +141,7 @@ describe('renderReportSummary', () => {
 	const renderOptions = {
 		title: 'Test Report',
 		reportUrl: 'https://example.com/report',
-		additionalDetails: 'For more information, see our [documentation](https://example.com/docs)',
+		customInfo: 'For more information, see our [documentation](https://example.com/docs)',
 		commit: '1234567'
 	}
 	const getReportSummary = async (): Promise<string> =>

--- a/dist/index.js
+++ b/dist/index.js
@@ -31961,7 +31961,8 @@ exports.icons = {
         duration: 'clock',
         link: 'link-external',
         report: 'package',
-        commit: 'git-pull-request'
+        commit: 'git-pull-request',
+        info: 'info'
     },
     emojis: {
         failed: '❌',
@@ -31972,7 +31973,8 @@ exports.icons = {
         duration: '',
         link: '',
         report: '',
-        commit: ''
+        commit: '',
+        info: 'ℹ️'
     }
 };
 const iconColors = {
@@ -32046,12 +32048,14 @@ async function report() {
     const reportUrl = (0, core_1.getInput)('report-url');
     const reportTag = (0, core_1.getInput)('report-tag') || workflow;
     const commentTitle = (0, core_1.getInput)('comment-title') || 'Playwright test results';
+    const additionalDetails = (0, core_1.getInput)('additional-details');
     const iconStyle = (0, core_1.getInput)('icon-style') || 'octicons';
     const jobSummary = (0, core_1.getInput)('job-summary') ? (0, core_1.getBooleanInput)('job-summary') : false;
     (0, core_1.debug)(`Report file: ${reportFile}`);
     (0, core_1.debug)(`Report url: ${reportUrl || '(none)'}`);
     (0, core_1.debug)(`Report tag: ${reportTag || '(none)'}`);
     (0, core_1.debug)(`Comment title: ${commentTitle}`);
+    (0, core_1.debug)(`Additional details: ${additionalDetails || '(none)'}`);
     let ref = github_1.context.ref;
     let sha = github_1.context.sha;
     const octokit = (0, github_1.getOctokit)(token);
@@ -32082,6 +32086,7 @@ async function report() {
     const summary = (0, report_1.renderReportSummary)(report, {
         commit: sha,
         title: commentTitle,
+        additionalDetails,
         reportUrl,
         iconStyle
     });
@@ -32266,7 +32271,7 @@ function buildTitle(...paths) {
     return { title, path };
 }
 exports.buildTitle = buildTitle;
-function renderReportSummary(report, { commit, message, title, reportUrl, iconStyle } = {}) {
+function renderReportSummary(report, { commit, message, title, additionalDetails, reportUrl, iconStyle } = {}) {
     const { duration, failed, passed, flaky, skipped } = report;
     const icon = (symbol) => (0, icons_1.renderIcon)(symbol, { iconStyle });
     const paragraphs = [];
@@ -32287,7 +32292,8 @@ function renderReportSummary(report, { commit, message, title, reportUrl, iconSt
         `${icon('stats')}  ${report.tests.length} ${(0, formatting_1.n)('test', report.tests.length)} across ${report.suites.length} ${(0, formatting_1.n)('suite', report.suites.length)}`,
         `${icon('duration')}  ${duration ? (0, formatting_1.formatDuration)(duration) : 'unknown'}`,
         commit && message ? `${icon('commit')}  ${message} (${commit.slice(0, 7)})` : '',
-        commit && !message ? `${icon('commit')}  ${commit.slice(0, 7)}` : ''
+        commit && !message ? `${icon('commit')}  ${commit.slice(0, 7)}` : '',
+        additionalDetails ? `${icon('info')}  ${additionalDetails}` : ''
     ];
     paragraphs.push(stats.filter(Boolean).join('  \n'));
     // Lists of failed/skipped tests

--- a/dist/index.js
+++ b/dist/index.js
@@ -32048,14 +32048,14 @@ async function report() {
     const reportUrl = (0, core_1.getInput)('report-url');
     const reportTag = (0, core_1.getInput)('report-tag') || workflow;
     const commentTitle = (0, core_1.getInput)('comment-title') || 'Playwright test results';
-    const additionalDetails = (0, core_1.getInput)('additional-details');
+    const customInfo = (0, core_1.getInput)('custom-info');
     const iconStyle = (0, core_1.getInput)('icon-style') || 'octicons';
     const jobSummary = (0, core_1.getInput)('job-summary') ? (0, core_1.getBooleanInput)('job-summary') : false;
     (0, core_1.debug)(`Report file: ${reportFile}`);
     (0, core_1.debug)(`Report url: ${reportUrl || '(none)'}`);
     (0, core_1.debug)(`Report tag: ${reportTag || '(none)'}`);
     (0, core_1.debug)(`Comment title: ${commentTitle}`);
-    (0, core_1.debug)(`Additional details: ${additionalDetails || '(none)'}`);
+    (0, core_1.debug)(`Custom info: ${customInfo || '(none)'}`);
     let ref = github_1.context.ref;
     let sha = github_1.context.sha;
     const octokit = (0, github_1.getOctokit)(token);
@@ -32086,7 +32086,7 @@ async function report() {
     const summary = (0, report_1.renderReportSummary)(report, {
         commit: sha,
         title: commentTitle,
-        additionalDetails,
+        customInfo,
         reportUrl,
         iconStyle
     });
@@ -32271,7 +32271,7 @@ function buildTitle(...paths) {
     return { title, path };
 }
 exports.buildTitle = buildTitle;
-function renderReportSummary(report, { commit, message, title, additionalDetails, reportUrl, iconStyle } = {}) {
+function renderReportSummary(report, { commit, message, title, customInfo, reportUrl, iconStyle } = {}) {
     const { duration, failed, passed, flaky, skipped } = report;
     const icon = (symbol) => (0, icons_1.renderIcon)(symbol, { iconStyle });
     const paragraphs = [];
@@ -32293,7 +32293,7 @@ function renderReportSummary(report, { commit, message, title, additionalDetails
         `${icon('duration')}  ${duration ? (0, formatting_1.formatDuration)(duration) : 'unknown'}`,
         commit && message ? `${icon('commit')}  ${message} (${commit.slice(0, 7)})` : '',
         commit && !message ? `${icon('commit')}  ${commit.slice(0, 7)}` : '',
-        additionalDetails ? `${icon('info')}  ${additionalDetails}` : ''
+        customInfo ? `${icon('info')}  ${customInfo}` : ''
     ];
     paragraphs.push(stats.filter(Boolean).join('  \n'));
     // Lists of failed/skipped tests

--- a/src/icons.ts
+++ b/src/icons.ts
@@ -14,7 +14,8 @@ export const icons: Record<string, IconSet> = {
 		duration: 'clock',
 		link: 'link-external',
 		report: 'package',
-		commit: 'git-pull-request'
+		commit: 'git-pull-request',
+		info: 'info'
 	},
 	emojis: {
 		failed: '❌',
@@ -25,7 +26,8 @@ export const icons: Record<string, IconSet> = {
 		duration: '',
 		link: '',
 		report: '',
-		commit: ''
+		commit: '',
+		info: 'ℹ️'
 	}
 }
 

--- a/src/index.ts
+++ b/src/index.ts
@@ -42,6 +42,7 @@ export async function report(): Promise<void> {
 	const reportUrl = getInput('report-url')
 	const reportTag = getInput('report-tag') || workflow
 	const commentTitle = getInput('comment-title') || 'Playwright test results'
+	const additionalDetails = getInput('additional-details')
 	const iconStyle = getInput('icon-style') || 'octicons'
 	const jobSummary = getInput('job-summary') ? getBooleanInput('job-summary') : false
 
@@ -49,6 +50,7 @@ export async function report(): Promise<void> {
 	debug(`Report url: ${reportUrl || '(none)'}`)
 	debug(`Report tag: ${reportTag || '(none)'}`)
 	debug(`Comment title: ${commentTitle}`)
+	debug(`Additional details: ${additionalDetails || '(none)'}`)
 
 	let ref: string = context.ref
 	let sha: string = context.sha
@@ -83,6 +85,7 @@ export async function report(): Promise<void> {
 	const summary = renderReportSummary(report, {
 		commit: sha,
 		title: commentTitle,
+		additionalDetails,
 		reportUrl,
 		iconStyle
 	})

--- a/src/index.ts
+++ b/src/index.ts
@@ -42,7 +42,7 @@ export async function report(): Promise<void> {
 	const reportUrl = getInput('report-url')
 	const reportTag = getInput('report-tag') || workflow
 	const commentTitle = getInput('comment-title') || 'Playwright test results'
-	const additionalDetails = getInput('additional-details')
+	const customInfo = getInput('custom-info')
 	const iconStyle = getInput('icon-style') || 'octicons'
 	const jobSummary = getInput('job-summary') ? getBooleanInput('job-summary') : false
 
@@ -50,7 +50,7 @@ export async function report(): Promise<void> {
 	debug(`Report url: ${reportUrl || '(none)'}`)
 	debug(`Report tag: ${reportTag || '(none)'}`)
 	debug(`Comment title: ${commentTitle}`)
-	debug(`Additional details: ${additionalDetails || '(none)'}`)
+	debug(`Custom info: ${customInfo || '(none)'}`)
 
 	let ref: string = context.ref
 	let sha: string = context.sha
@@ -85,7 +85,7 @@ export async function report(): Promise<void> {
 	const summary = renderReportSummary(report, {
 		commit: sha,
 		title: commentTitle,
-		additionalDetails,
+		customInfo,
 		reportUrl,
 		iconStyle
 	})

--- a/src/report.ts
+++ b/src/report.ts
@@ -71,6 +71,7 @@ interface ReportRenderOptions {
 	commit?: string
 	message?: string
 	title?: string
+	additionalDetails?: string
 	reportUrl?: string
 	iconStyle?: keyof typeof icons
 }
@@ -182,7 +183,7 @@ export function buildTitle(...paths: string[]): { title: string; path: string[] 
 
 export function renderReportSummary(
 	report: ReportSummary,
-	{ commit, message, title, reportUrl, iconStyle }: ReportRenderOptions = {}
+	{ commit, message, title, additionalDetails, reportUrl, iconStyle }: ReportRenderOptions = {}
 ): string {
 	const { duration, failed, passed, flaky, skipped } = report
 	const icon = (symbol: string): string => renderIcon(symbol, { iconStyle })
@@ -214,7 +215,8 @@ export function renderReportSummary(
 		)}`,
 		`${icon('duration')}  ${duration ? formatDuration(duration) : 'unknown'}`,
 		commit && message ? `${icon('commit')}  ${message} (${commit.slice(0, 7)})` : '',
-		commit && !message ? `${icon('commit')}  ${commit.slice(0, 7)}` : ''
+		commit && !message ? `${icon('commit')}  ${commit.slice(0, 7)}` : '',
+		additionalDetails ? `${icon('info')}  ${additionalDetails}` : ''
 	]
 	paragraphs.push(stats.filter(Boolean).join('  \n'))
 

--- a/src/report.ts
+++ b/src/report.ts
@@ -71,7 +71,7 @@ interface ReportRenderOptions {
 	commit?: string
 	message?: string
 	title?: string
-	additionalDetails?: string
+	customInfo?: string
 	reportUrl?: string
 	iconStyle?: keyof typeof icons
 }
@@ -183,7 +183,7 @@ export function buildTitle(...paths: string[]): { title: string; path: string[] 
 
 export function renderReportSummary(
 	report: ReportSummary,
-	{ commit, message, title, additionalDetails, reportUrl, iconStyle }: ReportRenderOptions = {}
+	{ commit, message, title, customInfo, reportUrl, iconStyle }: ReportRenderOptions = {}
 ): string {
 	const { duration, failed, passed, flaky, skipped } = report
 	const icon = (symbol: string): string => renderIcon(symbol, { iconStyle })
@@ -216,7 +216,7 @@ export function renderReportSummary(
 		`${icon('duration')}  ${duration ? formatDuration(duration) : 'unknown'}`,
 		commit && message ? `${icon('commit')}  ${message} (${commit.slice(0, 7)})` : '',
 		commit && !message ? `${icon('commit')}  ${commit.slice(0, 7)}` : '',
-		additionalDetails ? `${icon('info')}  ${additionalDetails}` : ''
+		customInfo ? `${icon('info')}  ${customInfo}` : ''
 	]
 	paragraphs.push(stats.filter(Boolean).join('  \n'))
 


### PR DESCRIPTION
Adds an optional additional-details option to the action for
the purpose of providing a section to provide other details
not included in the report to PR submitters such as links
to other relevant documentation, readmes or playbooks.

Closes #199 
