### PR TITLE
Add command to re-run tests

### DIFF
--- a/README.md
+++ b/README.md
@@ -79,6 +79,11 @@ jobs:
     # Icon style to use: octicons | emojis
     # Default: octicons
     icon-style: 'octicons'
+
+    # Command used to run tests. If provided, a command to re-run failed or
+    # flaky tests will be printed for each section.
+    # Default: ''
+    test-command: 'npm run test --'
 ```
 
 ## Output

--- a/__tests__/index.test.ts
+++ b/__tests__/index.test.ts
@@ -128,6 +128,7 @@ describe('action', () => {
 		expect(getInputMock).toHaveBeenCalledWith('comment-title')
 		expect(getInputMock).toHaveBeenCalledWith('icon-style')
 		expect(getInputMock).toHaveBeenCalledWith('job-summary')
+		expect(getInputMock).toHaveBeenCalledWith('test-command')
 	})
 
 	it('debugs its inputs', async () => {

--- a/action.yml
+++ b/action.yml
@@ -35,6 +35,9 @@ inputs:
     description: 'The icons to use: octicons or emoji'
     required: false
     default: 'octicons'
+  test-command:
+    description: 'The command used to run the tests'
+    required: false
 
 outputs:
   summary:

--- a/src/formatting.ts
+++ b/src/formatting.ts
@@ -13,6 +13,10 @@ export function renderAccordion(summary: string, content: string, { open = false
 	return `<details ${open ? 'open' : ''}>${summary}\n\n${content.trim()}\n\n</details>`
 }
 
+export function renderCodeBlock(code: string, lang: string = ''): string {
+	return `\`\`\`${lang}\n${code}\n\`\`\``
+}
+
 export function formatDuration(milliseconds: number): string {
 	const SECOND = 1000
 	const MINUTE = 60 * SECOND

--- a/src/formatting.ts
+++ b/src/formatting.ts
@@ -13,7 +13,7 @@ export function renderAccordion(summary: string, content: string, { open = false
 	return `<details ${open ? 'open' : ''}>${summary}\n\n${content.trim()}\n\n</details>`
 }
 
-export function renderCodeBlock(code: string, lang: string = ''): string {
+export function renderCodeBlock(code: string, lang = ''): string {
 	return `\`\`\`${lang}\n${code}\n\`\`\``
 }
 

--- a/src/report.ts
+++ b/src/report.ts
@@ -250,7 +250,7 @@ export function renderReportSummary(
 		.join('\n\n')
 }
 
-function renderTestList(tests: TestSummary[], testCommand: string | undefined) {
+function renderTestList(tests: TestSummary[], testCommand: string | undefined): string {
 	const list = tests.map((test) => `  ${test.title}`).join('\n')
 	if (!testCommand) {
 		return list
@@ -280,6 +280,6 @@ function getTotalDuration(report: JSONReport, results: TestResultSummary[]): { d
 	return { duration, started }
 }
 
-export function getCommitUrl(repoUrl: string | undefined, sha: string) {
+export function getCommitUrl(repoUrl: string | undefined, sha: string): string | undefined {
 	return repoUrl ? `${repoUrl}/commit/${sha}` : undefined
 }

--- a/src/report.ts
+++ b/src/report.ts
@@ -7,7 +7,7 @@ import {
 } from '@playwright/test/reporter'
 import { debug } from '@actions/core'
 
-import { formatDuration, n, renderAccordion, upperCaseFirst } from './formatting'
+import { formatDuration, n, renderAccordion, renderCodeBlock, upperCaseFirst } from './formatting'
 import { icons, renderIcon } from './icons'
 
 export interface ReportSummary {
@@ -69,11 +69,13 @@ interface TestResultSummary {
 
 interface ReportRenderOptions {
 	commit?: string
+	commitUrl?: string
 	message?: string
 	title?: string
 	customInfo?: string
 	reportUrl?: string
 	iconStyle?: keyof typeof icons
+	testCommand?: string
 }
 
 export function isValidReport(report: unknown): report is JSONReport {
@@ -183,7 +185,7 @@ export function buildTitle(...paths: string[]): { title: string; path: string[] 
 
 export function renderReportSummary(
 	report: ReportSummary,
-	{ commit, message, title, customInfo, reportUrl, iconStyle }: ReportRenderOptions = {}
+	{ commit, commitUrl, message, title, customInfo, reportUrl, iconStyle, testCommand }: ReportRenderOptions = {}
 ): string {
 	const { duration, failed, passed, flaky, skipped } = report
 	const icon = (symbol: string): string => renderIcon(symbol, { iconStyle })
@@ -207,6 +209,9 @@ export function renderReportSummary(
 
 	paragraphs.push(`#### Details`)
 
+	const shortCommit = commit?.slice(0, 7)
+	const commitText = commitUrl ? `[${shortCommit}](${commitUrl})` : shortCommit
+
 	const stats = [
 		reportUrl ? `${icon('report')}  [Open report ↗︎](${reportUrl})` : '',
 		`${icon('stats')}  ${report.tests.length} ${n('test', report.tests.length)} across ${report.suites.length} ${n(
@@ -214,8 +219,8 @@ export function renderReportSummary(
 			report.suites.length
 		)}`,
 		`${icon('duration')}  ${duration ? formatDuration(duration) : 'unknown'}`,
-		commit && message ? `${icon('commit')}  ${message} (${commit.slice(0, 7)})` : '',
-		commit && !message ? `${icon('commit')}  ${commit.slice(0, 7)}` : '',
+		commitText && message ? `${icon('commit')}  ${message} (${commitText})` : '',
+		commitText && !message ? `${icon('commit')}  ${commitText}` : '',
 		customInfo ? `${icon('info')}  ${customInfo}` : ''
 	]
 	paragraphs.push(stats.filter(Boolean).join('  \n'))
@@ -227,9 +232,9 @@ export function renderReportSummary(
 		const tests = report[status]
 		if (tests.length) {
 			const summary = `${upperCaseFirst(status)} tests`
-			const list = tests.map((test) => test.title).join('\n  ')
+			const content = renderTestList(tests, status !== 'skipped' ? testCommand : undefined)
 			const open = status === 'failed'
-			return renderAccordion(summary, list, { open })
+			return renderAccordion(summary, content, { open })
 		}
 	})
 	paragraphs.push(
@@ -243,6 +248,18 @@ export function renderReportSummary(
 		.map((p) => p.trim())
 		.filter(Boolean)
 		.join('\n\n')
+}
+
+function renderTestList(tests: TestSummary[], testCommand: string | undefined) {
+	const list = tests.map((test) => `  ${test.title}`).join('\n')
+	if (!testCommand) {
+		return list
+	}
+
+	const testIds = tests.map((test) => `${test.file}:${test.line}`).join(' ')
+	const command = `${testCommand} ${testIds}`
+
+	return `${list}\n\n${renderCodeBlock(command)}`
 }
 
 function getTotalDuration(report: JSONReport, results: TestResultSummary[]): { duration: number; started: Date } {
@@ -261,4 +278,8 @@ function getTotalDuration(report: JSONReport, results: TestResultSummary[]): { d
 		}
 	}
 	return { duration, started }
+}
+
+export function getCommitUrl(repoUrl: string | undefined, sha: string) {
+	return repoUrl ? `${repoUrl}/commit/${sha}` : undefined
 }


### PR DESCRIPTION
This adds a code block which let's users quickly copy a command to re-run failed or flaky tests.

Also made the commit URL a link as a small quality of life improvement.

<img width="900" alt="image" src="https://github.com/user-attachments/assets/c075a45d-239c-4bf4-85bc-ba144aae01c2">
