### PR TITLE
Add support for footer content

### DIFF
--- a/README.md
+++ b/README.md
@@ -84,6 +84,10 @@ jobs:
     # flaky tests will be printed for each section.
     # Default: ''
     test-command: 'npm run test --'
+
+    # Additional content to add to the comment below the test report.
+    # Default: ''
+    footer: ''
 ```
 
 ## Output

--- a/__tests__/index.test.ts
+++ b/__tests__/index.test.ts
@@ -129,6 +129,7 @@ describe('action', () => {
 		expect(getInputMock).toHaveBeenCalledWith('icon-style')
 		expect(getInputMock).toHaveBeenCalledWith('job-summary')
 		expect(getInputMock).toHaveBeenCalledWith('test-command')
+		expect(getInputMock).toHaveBeenCalledWith('footer')
 	})
 
 	it('debugs its inputs', async () => {

--- a/action.yml
+++ b/action.yml
@@ -30,7 +30,7 @@ inputs:
   job-summary:
     description: 'Create a job summary comment for the workflow run'
     required: false
-    default: false
+    default: 'false'
   icon-style:
     description: 'The icons to use: octicons or emoji'
     required: false
@@ -38,6 +38,10 @@ inputs:
   test-command:
     description: 'The command used to run the tests'
     required: false
+  footer:
+    description: 'Additional content to add to the comment below the test report'
+    required: false
+    default: ''
 
 outputs:
   summary:

--- a/dist/index.js
+++ b/dist/index.js
@@ -32063,6 +32063,7 @@ async function report() {
     const iconStyle = (0, core_1.getInput)('icon-style') || 'octicons';
     const jobSummary = (0, core_1.getInput)('job-summary') ? (0, core_1.getBooleanInput)('job-summary') : false;
     const testCommand = (0, core_1.getInput)('test-command');
+    const footer = (0, core_1.getInput)('footer');
     (0, core_1.debug)(`Report file: ${reportFile}`);
     (0, core_1.debug)(`Report url: ${reportUrl || '(none)'}`);
     (0, core_1.debug)(`Report tag: ${reportTag || '(none)'}`);
@@ -32120,7 +32121,8 @@ async function report() {
         customInfo,
         reportUrl,
         iconStyle,
-        testCommand
+        testCommand,
+        footer
     });
     const prefix = `<!-- playwright-report-github-action -- ${reportTag} -->`;
     const body = `${prefix}\n\n${summary}`;
@@ -32302,7 +32304,7 @@ function buildTitle(...paths) {
     return { title, path };
 }
 exports.buildTitle = buildTitle;
-function renderReportSummary(report, { commit, commitUrl, message, title, customInfo, reportUrl, iconStyle, testCommand } = {}) {
+function renderReportSummary(report, { commit, commitUrl, message, title, customInfo, reportUrl, iconStyle, testCommand, footer } = {}) {
     const { duration, failed, passed, flaky, skipped } = report;
     const icon = (symbol) => (0, icons_1.renderIcon)(symbol, { iconStyle });
     const paragraphs = [];
@@ -32344,6 +32346,9 @@ function renderReportSummary(report, { commit, commitUrl, message, title, custom
         .filter(Boolean)
         .map((md) => md.trim())
         .join('\n'));
+    if (footer) {
+        paragraphs.push(footer);
+    }
     return paragraphs
         .map((p) => p.trim())
         .filter(Boolean)

--- a/src/index.ts
+++ b/src/index.ts
@@ -57,6 +57,7 @@ export async function report(): Promise<void> {
 	const iconStyle = getInput('icon-style') || 'octicons'
 	const jobSummary = getInput('job-summary') ? getBooleanInput('job-summary') : false
 	const testCommand = getInput('test-command')
+	const footer = getInput('footer')
 
 	debug(`Report file: ${reportFile}`)
 	debug(`Report url: ${reportUrl || '(none)'}`)
@@ -125,7 +126,8 @@ export async function report(): Promise<void> {
 		customInfo,
 		reportUrl,
 		iconStyle,
-		testCommand
+		testCommand,
+		footer
 	})
 
 	const prefix = `<!-- playwright-report-github-action -- ${reportTag} -->`

--- a/src/report.ts
+++ b/src/report.ts
@@ -76,6 +76,7 @@ interface ReportRenderOptions {
 	reportUrl?: string
 	iconStyle?: keyof typeof icons
 	testCommand?: string
+	footer?: string
 }
 
 export function isValidReport(report: unknown): report is JSONReport {
@@ -185,7 +186,7 @@ export function buildTitle(...paths: string[]): { title: string; path: string[] 
 
 export function renderReportSummary(
 	report: ReportSummary,
-	{ commit, commitUrl, message, title, customInfo, reportUrl, iconStyle, testCommand }: ReportRenderOptions = {}
+	{ commit, commitUrl, message, title, customInfo, reportUrl, iconStyle, testCommand, footer }: ReportRenderOptions = {}
 ): string {
 	const { duration, failed, passed, flaky, skipped } = report
 	const icon = (symbol: string): string => renderIcon(symbol, { iconStyle })
@@ -243,6 +244,10 @@ export function renderReportSummary(
 			.map((md) => (md as string).trim())
 			.join('\n')
 	)
+
+	if (footer) {
+		paragraphs.push(footer)
+	}
 
 	return paragraphs
 		.map((p) => p.trim())


### PR DESCRIPTION
Adds a `footer` option to support additional content to display below the report summary. This can help when displaying additional instructions or warnings as part of the report.