### PR TITLE
Export raw report data for high-level customizing

### DIFF
--- a/action.yml
+++ b/action.yml
@@ -48,6 +48,8 @@ inputs:
     default: ''
 
 outputs:
+  raw-data:
+    description: 'The raw data of the test report'
   summary:
     description: 'The rendered markdown summary of the test report'
   comment-id:

--- a/src/index.ts
+++ b/src/index.ts
@@ -197,6 +197,7 @@ export async function report(): Promise<void> {
 		setSummary.addRaw(summary).write()
 	}
 
+	setOutput('raw-data', report)
 	setOutput('summary', summary)
 	setOutput('comment-id', commentId)
 }

--- a/src/index.ts
+++ b/src/index.ts
@@ -197,7 +197,7 @@ export async function report(): Promise<void> {
 		setSummary.addRaw(summary).write()
 	}
 
-	setOutput('raw-data', report)
+	setOutput('raw-data', JSON.stringify(report))
 	setOutput('summary', summary)
 	setOutput('comment-id', commentId)
 }


### PR DESCRIPTION
I'm using this action to comment the results of my Playwright tests. However, I found it inconvenient that I couldn't easily customize the comment format. So, I modified it to output raw data, allowing for high-level customization.

This can be used in the following way:
- `${{ fromJSON(steps.summary.outputs.raw-data).files }}'`
- `${{ fromJSON(steps.summary.outputs.raw-data).failed }}'`