### PR TITLE
Bump Node runtime to 24 across action and CI

### DIFF
--- a/.github/workflows/check-dist.yml
+++ b/.github/workflows/check-dist.yml
@@ -37,7 +37,7 @@ jobs:
       - name: Setup Node.js
         uses: actions/setup-node@v6
         with:
-          node-version: 18
+          node-version: 24
           cache: npm
 
       - name: Install Dependencies

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -20,7 +20,7 @@ jobs:
         id: setup-node
         uses: actions/setup-node@v6
         with:
-          node-version: 18
+          node-version: 24
           cache: npm
 
       - name: Install Dependencies

--- a/action.yml
+++ b/action.yml
@@ -62,5 +62,5 @@ outputs:
     description: 'The raw data of the test report'
 
 runs:
-  using: node20
+  using: node24
   main: dist/index.js


### PR DESCRIPTION
Fixes https://github.com/daun/playwright-report-summary/issues/351

`action.yml` now declares `using: node24` (Node 20 is deprecated on GitHub Actions runners as of Sept 2025 and will be forced to 24 in June 2026). CI and check-dist workflows updated to match.

I did not update the node version declared in `package.json`'s `engines` property because it's not related to GitHub Actions, but I can upgrade that to node 24 as well if you want.